### PR TITLE
Fixes a icon rotation bug in the validator

### DIFF
--- a/validator/index.html
+++ b/validator/index.html
@@ -42,9 +42,9 @@
       if (importUrl) {
           var re = /(\d+)_(\d+)_(\d+).osm/;
           var arr = re.exec(importUrl);
-          var z = arr[1]; 
-          var x = arr[2]; 
-          var y = arr[3]; 
+          var z = arr[1];
+          var x = arr[2];
+          var y = arr[3];
           bbox = merc.bbox(x,y,z);
           center = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3])/2];
           zoom = z-1;
@@ -190,7 +190,8 @@
             "icon-rotate": {
               "property": "ca",
               "stops": iconRotations()
-            }
+            },
+            "icon-rotation-alignment": "map"
           },
           "paint": {
             "icon-opacity": {
@@ -212,7 +213,8 @@
             "icon-rotate": {
               "property": "ca",
               "stops": iconRotations()
-            }
+            },
+            "icon-rotation-alignment": "map"
           },
           "filter": ["==", "key", "sd41At97Yp44GdWYGWUlxg"]
         });


### PR DESCRIPTION
Aligns the mapillary icons to the map. Otherwise, the icons don't rotate if the map bearing is changed.

Before:
![before](https://cloud.githubusercontent.com/assets/11095038/21226936/c645f3ca-c2fd-11e6-87a9-ba32d625d2e3.gif)

After:
![after](https://cloud.githubusercontent.com/assets/11095038/21226939/c8da2e08-c2fd-11e6-8851-ea46cc6ceedb.gif)

cc: @maning @bdon 